### PR TITLE
feat: make props.action.label/onClick optional

### DIFF
--- a/src/Toast.vue
+++ b/src/Toast.vue
@@ -32,10 +32,10 @@ defineEmits(['closeToast'])
           v-bind="action.buttonProps"
           @click="() => {
             $emit('closeToast')
-            action?.onClick()
+            action?.onClick?.()
           }"
+          :text="action.label"
         >
-          {{ action.label }}
         </VBtn>
       </VCardActions>
     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,8 +16,8 @@ export interface ToastProps {
   cardTextProps?: ExtractProps<typeof VCardText>
   cardActionsProps?: ExtractProps<typeof VCardActions>
   action?: {
-    label: string
-    onClick: () => void
+    label?: string
+    onClick?: () => void
     buttonProps?: ExtractProps<typeof VBtn>
   }
 }


### PR DESCRIPTION
Making `action.label` optional to use `VBtn`'s icon mode.
Making `action.onClick` optional to just close the toast.

```js
toast('Vuetify Sonner', {
  description: 'Stackable toast component for Vuetify.',
  action: {
    // label: '',
    // onClick: () => {},
    buttonProps: {
      icon: 'mdi-close',
      size: 'small',
    },
  },
})
```