### PR TITLE
fix: export css

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
       "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.mjs"
+    },
+    "./dist/*.css": {
+      "require": "./dist/*.css",
+      "import": "./dist/*.css"
     }
   },
   "main": "./dist/index.mjs",


### PR DESCRIPTION
With this fix, the built css can be correctly imported.

E.g. for nuxt:

```js
export default defineNuxtConfig({
  build: {
    transpile: ['vue-sonner']
  },
  css: ['vuetify-sonner/dist/index.css']
})
```