### PR TITLE
feat: add prependIcon prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ toast('Event has been created', {
   },
   cardActionsProps: {
     // v-card-actions props
+  },
+  prependIcon: 'mdi-check',
+  prependIconProps: {
+    // v-icon props
   }
 })
 ```

--- a/lib/Toast.vue
+++ b/lib/Toast.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { VBtn, VCard, VCardActions, VCardText, VSpacer } from 'vuetify/components'
+import { VBtn, VCard, VCardActions, VCardText, VSpacer, VIcon } from 'vuetify/components'
 import type { ToastProps } from './types'
 
 withDefaults(defineProps<ToastProps>(), {
@@ -8,16 +8,21 @@ withDefaults(defineProps<ToastProps>(), {
 })
 
 defineEmits(['closeToast'])
+
+defineOptions({
+  inheritAttrs: false,
+})
 </script>
 
 <template>
   <VCard class="card-snackbar" v-bind="cardProps">
     <div :class="{ 'd-flex flex-no-wrap justify-space-between': !vertical }">
-      <VCardText v-bind="cardTextProps">
-        <template v-if="description">
+      <VCardText v-bind="cardTextProps" :class="{ 'd-flex align-center': prependIcon }">
+        <VIcon v-if="prependIcon" class="mr-2" :icon="prependIcon" v-bind="prependIconProps" />
+        <div v-if="description">
           <div class="pb-1">{{ text }}</div>
           <p class="font-weight-light" v-html="description"></p>
-        </template>
+        </div>
         <template v-else>
           {{ text }}
         </template>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,5 @@
 import type { AllowedComponentProps, VNodeProps } from 'vue'
-import type { VBtn, VCard, VCardActions, VCardText } from 'vuetify/components'
+import type { VBtn, VCard, VCardActions, VCardText, VIcon } from 'vuetify/components'
 
 type ExtractProps<TComponent> =
   TComponent extends new () => {
@@ -20,4 +20,6 @@ export interface ToastProps {
     onClick?: () => void
     buttonProps?: ExtractProps<typeof VBtn>
   }
+  prependIcon?: string
+  prependIconProps?: ExtractProps<typeof VIcon>
 }


### PR DESCRIPTION
Closes https://github.com/wobsoriano/vuetify-sonner/issues/9

```ts
toast('Vuetify Sonner', {
  description: 'Stackable toast component for Vuetify.',
  prependIcon: 'mdi-check',
})
```

![Screenshot 2023-12-23 at 12 54 53 AM](https://github.com/wobsoriano/vuetify-sonner/assets/13049130/d097e976-a10d-43bd-b6f1-39574c430a74)
