### PR TITLE
feat: add toast types

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -19,7 +19,24 @@ function toastFunction(text: string, options?: Options) {
   })
 }
 
+function createToastFunction(color: string, icon: string) {
+  return function (text: string, options?: Options) {
+    return toastFunction(text, {
+      prependIcon: icon,
+      cardProps: {
+        color,
+        ...options?.cardProps,
+      },
+      ...options,
+    })
+  }
+}
+
 export const toast = Object.assign(toastFunction, {
+  success: createToastFunction('success', 'mdi-check-circle'),
+  error: createToastFunction('error', 'mdi-alert-circle'),
+  warning: createToastFunction('warning', 'mdi-alert'),
+  info: createToastFunction('info', 'mdi-information'),
   dismiss(toastId?: number | string) {
     return toastOriginal.dismiss(toastId)
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import type { Position as PositionType } from 'vue-sonner/lib/types'
 import Hero from './Hero.vue'
 import Position from './Position.vue'
+import Types from './Types.vue'
 import Expand from './Expand.vue'
 import { VSonner } from '@/.'
 
@@ -19,6 +20,7 @@ const expand = ref(false)
         <div class="content">
           <Position v-model:position="position" />
           <Expand v-model:expand="expand" />
+          <Types />
         </div>
       </div>
     </v-main>

--- a/src/Types.vue
+++ b/src/Types.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { toast } from '@/.'
+</script>
+
+<template>
+  <div>
+    <h2>Types</h2>
+    <p>You can customize the type of toast you want to render, and pass an options object as the second argument.</p>
+    <div class="buttons mt-2">
+      <v-btn @click="toast('Event has been created')">
+        Default
+      </v-btn>
+      <v-btn @click="toast.success('Event has been created')">
+        Success
+      </v-btn>
+      <v-btn @click="toast.info('Be at the area 10 minutes before the time')">
+        Info
+      </v-btn>
+      <v-btn @click="toast.warning('Event start time cannot be earlier than 8am')">
+        Warning
+      </v-btn>
+      <v-btn @click="toast.error('Event has not been created')">
+        Error
+      </v-btn>
+    </div>
+  </div>
+</template>
+
+<style>
+.buttons {
+  display: flex;
+  gap: 8px;
+  overflow: auto;
+  margin: 0 calc(-1 * var(--side-padding));
+  padding: 4px var(--side-padding);
+  position: relative;
+}
+</style>


### PR DESCRIPTION
This PR adds toast types:

```ts
toast.success('Event has been created')
toast.error('Event has not been created')
toast.info('Be at the area 10 minutes before the time')
toast.warning('Event start time cannot be earlier than 8am')
```