### PR TITLE
feature: avatars and progress bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Behind the scenes, the toast component uses Vuetify [Cards](https://vuetifyjs.co
 
 ### Position
 
-You can change the position through the `position` prop on the <VSonner /> component. Default is `bottom-center`.
+You can change the position through the `position` prop on the `<VSonner />` component. Default is `bottom-center`.
 
 ```vue
 <VSonner position="top-center" />
@@ -85,13 +85,15 @@ Toasts can also be expanded by default through the `expand` prop. You can also c
 <VSonner expand :visible-toasts="9" />
 ```
 
-### Styling a toast
+### Toast Options
 
 ```js
 toast('Event has been created', {
+  description: 'Some more context of the notification' // subtitle of the snackbar
   cardProps: {
     color: 'success',
     class: 'my-toast',
+    // v-card props
   },
   cardTextProps: {
     // v-card-text props
@@ -102,6 +104,22 @@ toast('Event has been created', {
   prependIcon: 'mdi-check-circle',
   prependIconProps: {
     // v-icon props
+  },
+  progressBar: boolean, // show or hide countdown progress bar
+  progressBarProps: {
+    // v-progress-linear props
+  },
+  reverseProgressBar: boolean // changes progress bar direction
+  loading: boolean, // makes progressbar indeterminate
+  avatar: 'https://url.to/my/image.jpg' // avatar image url,
+  multipleAvatars: [
+    'https://url.to/image/1.jpg',
+    'https://url.to/image/2.jpg',
+    'https://url.to/image/3.jpg'
+    // will display first 5 images
+  ],
+  avatarProps: {
+    // v-avatar props
   }
 })
 ```
@@ -161,6 +179,28 @@ You can focus on the toast area by pressing ⌥/alt + T. You can override it by 
 ```vue
 <VSonner :hotkey="['KeyC']" />
 ```
+
+### Use Underlying `Vue-Sonner`
+
+`vuetify-sonner`, as a wrapper over the `vue-sonner` library, grants access to all the underlying methods and properties of `vue-sonner` by using the `toast.toastOriginal` property, e.g.
+
+```js
+// Using Vue-Sonners Promise toast
+import { toast } from 'vuetify-sonner'
+
+const promise = () => new Promise((resolve) => setTimeout(resolve, 2000));
+
+toast.toastOriginal
+  .promise(promise, {
+    loading: 'Loading...', 
+    success: (data) => {
+      return `${data} toast has been added`;
+    },
+    error: (data: any) => 'Error',
+  });
+```
+
+See [here for more on using vue-sonner](https://vue-sonner.vercel.app/)
 
 ## Nuxt Usage
 

--- a/lib/ProgressBar.vue
+++ b/lib/ProgressBar.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+  import { VProgressLinear } from 'vuetify/components'
+  import type { ExternalToast } from 'vue-sonner/lib/types'
+  import type { ToastProps } from './types'
+  import { onMounted, ref, watch, onBeforeUnmount } from 'vue';
+
+  type ProgressProps = Pick<ExternalToast, 'duration'> 
+    & Pick<ToastProps, 'progressBarProps'> 
+    & {isPaused: boolean, reverseProgressBar: boolean}
+  
+  const props = withDefaults(defineProps<ProgressProps>(), {
+    duration: 5000,
+    isPaused: false,
+    reverseProgressBar: false,
+  })
+
+  let value = props.reverseProgressBar ? ref(0) : ref(5000)
+
+  let interval: ReturnType<typeof setInterval>
+
+  watch(() => props.isPaused, (newValue) => {
+    if(!newValue && !props.progressBarProps?.indeterminate) syncProgressBar()
+  })
+
+  const syncProgressBar = () => {
+    interval = setTimeout(() => {
+      if(props.isPaused) return;
+      props.reverseProgressBar ? value.value += 120 : value.value -= 120
+      if (value.value <= 0 && !props.reverseProgressBar){
+        value.value = 0
+        clearInterval(interval)
+      } else if (value.value >= props.duration && props.reverseProgressBar) {
+        value.value = props.duration
+        clearInterval(interval)
+      } else {
+        syncProgressBar()
+      }
+    }, 100);
+  }
+
+  onMounted(() => {
+    if(!props.progressBarProps?.indeterminate){
+      value.value = props.reverseProgressBar ? 0 : props.duration
+      syncProgressBar()
+    }
+  })
+
+  onBeforeUnmount (() => {
+    clearInterval(interval)
+  })
+</script>
+<template>
+  <VProgressLinear v-bind="props.progressBarProps" :model-value="Math.floor(100 * (value / props.duration))"></VProgressLinear>
+</template>

--- a/lib/Toast.vue
+++ b/lib/Toast.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-import { VBtn, VCard, VCardActions, VCardText, VIcon, VSpacer } from 'vuetify/components'
+import { VBtn, VCard, VCardActions, VCardText, VIcon, VSpacer, VAvatar, VImg, VProgressCircular, VExpandTransition } from 'vuetify/components'
 import type { ToastProps } from './types'
+import ProgressBar from './ProgressBar.vue';
+import {ref} from 'vue';
+
+const isHovered = ref(false)
 
 defineOptions({
   inheritAttrs: false,
@@ -8,6 +12,8 @@ defineOptions({
 
 withDefaults(defineProps<ToastProps>(), {
   vertical: false,
+  progressBar: true,
+  progressDuration: 5000,
   cardActionsProps: () => ({}),
 })
 
@@ -15,9 +21,35 @@ defineEmits(['closeToast'])
 </script>
 
 <template>
-  <VCard class="card-snackbar" v-bind="cardProps">
+  <VCard @mouseenter="isHovered = true" @mouseleave="isHovered = false" class="card-snackbar" v-bind="cardProps">
     <div :class="{ 'd-flex flex-no-wrap justify-space-between': !vertical }">
-      <VCardText v-bind="cardTextProps" :class="{ 'd-flex align-center': prependIcon }">
+      <VCardText v-bind="cardTextProps" :class="{ 'd-flex align-center': prependIcon || avatar || multipleAvatars }">
+        <VAvatar v-if="avatar" class="mr-2" v-bind="avatarProps">
+          <VImg :src="avatar" cover>
+            <template v-slot:placeholder>
+              <div class="d-flex align-center justify-center fill-height">
+                <VProgressCircular
+                  color="grey-lighten-2"
+                  indeterminate
+                ></VProgressCircular>
+              </div>
+            </template>
+          </VImg>
+        </VAvatar>
+        <div v-else-if="multipleAvatars" class="d-flex align-center mr-8">
+          <VAvatar v-for="img, i in multipleAvatars.length <= 5 ? multipleAvatars : multipleAvatars.slice(0, 5)" v-bind="avatarProps" :key="i" class="mr-n6" :style="{zIndex: 5-i}">
+            <VImg :src="img" cover>
+              <template v-slot:placeholder>
+                <div class="d-flex align-center justify-center fill-height">
+                  <VProgressCircular
+                    color="grey-lighten-2"
+                    indeterminate
+                  ></VProgressCircular>
+                </div>
+              </template>
+            </VImg>
+          </VAvatar>
+        </div>
         <VIcon v-if="prependIcon" class="mr-2" :icon="prependIcon" v-bind="prependIconProps" />
         <div v-if="description">
           <div class="pb-1">
@@ -41,6 +73,9 @@ defineEmits(['closeToast'])
         />
       </VCardActions>
     </div>
+    <VExpandTransition>
+      <ProgressBar v-show="progressBar" :duration="progressDuration" :progress-bar-props="progressBarProps" :is-paused="isHovered" :reverse-progress-bar="reverseProgressBar"></ProgressBar>
+    </VExpandTransition>
   </VCard>
 </template>
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,6 +11,12 @@ function toastFunction(text: string, options?: Options) {
   const { description, action, ...rest } = options || {}
   return toastOriginal.custom(markRaw(h(Toast, {
     ...rest,
+    progressBar: options?.progressBar ?? true,
+    progressDuration: options?.duration ?? 5000,
+    progressBarProps: {
+      ...options?.progressBarProps,
+      indeterminate: options?.loading
+    },
     description,
     action,
     text,
@@ -35,9 +41,11 @@ function createToastFunction(color: string, icon: string) {
 
 export const toast = Object.assign(toastFunction, {
   success: createToastFunction('success', 'mdi-check-circle'),
-  error: createToastFunction('error', 'mdi-alert-circle'),
+  error: createToastFunction('error', 'mdi-cancel'),
   warning: createToastFunction('warning', 'mdi-alert'),
-  info: createToastFunction('info', 'mdi-information'),
+  info: createToastFunction('info', 'mdi-alert-circle'),
+  primary: createToastFunction('primary', 'mdi-bell'),
+  secondary: createToastFunction('secondary', 'mdi-bell'),
   dismiss(toastId?: number | string) {
     return toastOriginal.dismiss(toastId)
   },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,5 @@
 import type { VNodeProps } from 'vue'
-import type { VBtn, VCard, VCardActions, VCardText, VIcon } from 'vuetify/components'
+import type { VBtn, VCard, VCardActions, VCardText, VIcon, VAvatar, VProgressLinear } from 'vuetify/components'
 
 type ExtractProps<TComponent> =
   TComponent extends new () => {
@@ -22,4 +22,12 @@ export interface ToastProps {
   }
   prependIcon?: string
   prependIconProps?: ExtractProps<typeof VIcon>
+  avatar?: string
+  multipleAvatars?: string[]
+  avatarProps?: ExtractProps<typeof VAvatar>
+  progressBar?: boolean
+  reverseProgressBar?: boolean
+  progressDuration?: number
+  progressBarProps?: ExtractProps<typeof VProgressLinear>
+  loading?: boolean
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,21 +6,62 @@ import Position from './Position.vue'
 import Types from './Types.vue'
 import Expand from './Expand.vue'
 import { VSonner } from '@/.'
+import WithProgressBars from './WithProgressBars.vue'
+import WithAvatars from './WithAvatars.vue'
 
 const position = ref<PositionType>('bottom-right')
 const expand = ref(false)
+const range = ref([2, 9])
+const maxToasts = ref(3)
+
 </script>
 
 <template>
   <v-app>
     <v-main>
-      <VSonner :position="position" :expand="expand" />
+      <VSonner :position="position" :visible-toasts="maxToasts" :expand="expand" />
       <div class="container">
         <Hero />
         <div class="content">
           <Position v-model:position="position" />
+          <v-slider
+            v-model="maxToasts"
+            :max="range[1]"
+            :min="range[0]"
+            :show-ticks="true"
+            thumb-label="always"
+            
+            :step="1"
+            hint="Number of visible toasts at a time"
+            persistent-hint
+          >
+            <template v-slot:prepend>
+              <v-text-field
+                v-model="range[0]"
+                density="compact"
+                style="width: 70px"
+                type="number"
+                variant="outlined"
+                hide-details
+                single-line
+              ></v-text-field>
+            </template>
+            <template v-slot:append>
+              <v-text-field
+                v-model="range[1]"
+                density="compact"
+                style="width: 70px"
+                type="number"
+                variant="outlined"
+                hide-details
+                single-line
+              ></v-text-field>
+            </template>
+          </v-slider>
           <Expand v-model:expand="expand" />
           <Types />
+          <WithProgressBars />
+          <WithAvatars />
         </div>
       </div>
     </v-main>

--- a/src/Expand.vue
+++ b/src/Expand.vue
@@ -9,6 +9,7 @@ const emit = defineEmits(['update:expand'])
 function onClick(value: boolean) {
   toast('Event has been created', {
     description: 'Monday, January 3rd at 6:00pm',
+    prependIcon: '$vuetify',
   })
   emit('update:expand', value)
 }

--- a/src/Hero.vue
+++ b/src/Hero.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { ref } from 'vue'
 import { toast } from '@/.'
 </script>
 

--- a/src/Types.vue
+++ b/src/Types.vue
@@ -10,7 +10,7 @@ import { toast } from '@/.'
       <v-btn @click="toast('Event has been created')">
         Default
       </v-btn>
-      <v-btn @click="toast.success('Event has been created')">
+      <v-btn @click="toast.success('Something happened successfully')">
         Success
       </v-btn>
       <v-btn @click="toast.info('Be at the area 10 minutes before the time')">
@@ -21,6 +21,12 @@ import { toast } from '@/.'
       </v-btn>
       <v-btn @click="toast.error('Event has not been created')">
         Error
+      </v-btn>
+      <v-btn @click="toast.primary('Just a notification with primary color 💅')">
+        Primary
+      </v-btn>
+      <v-btn @click="toast.secondary('Another notification with secondary color 🎨', {prependIcon: 'mdi-thumb-up'})">
+        Secondary
       </v-btn>
     </div>
   </div>

--- a/src/WithAvatars.vue
+++ b/src/WithAvatars.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { toast } from '@/.'
+</script>
+<template>
+  <div>
+    <h2>Avatars</h2>
+    <p>You can add avatars to your toast</p>
+    <div class="buttons mt-2 mb-8">
+      <v-btn @click="toast('This toast has an avatar', {avatar: 'https://avatars.githubusercontent.com/u/739984?v=4'})">
+        Avatar
+      </v-btn>
+      <v-btn @click="toast.primary('This toast has an avatar', {avatar: 'https://avatars.githubusercontent.com/u/739984?v=4', prependIcon: '$vuetify', description: 'And an icon as well'})">
+        With Icon
+      </v-btn>
+      <v-btn @click="toast('This avatar is small and square', {avatar: 'https://avatars.githubusercontent.com/u/739984?v=4', avatarProps: {size: 'small', tile: true}, cardProps: {color: 'deep-purple'}})">
+        Avatar Props
+      </v-btn>
+      <v-btn @click="toast('Some people did a thing', {
+          cardProps: {
+            color: 'blue'
+          },
+          multipleAvatars: [
+            'https://randomuser.me/api/portraits/women/22.jpg',
+            'https://randomuser.me/api/portraits/women/21.jpg',
+            'https://randomuser.me/api/portraits/men/21.jpg',
+            // 'https://randomuser.me/api/portraits/women/20.jpg',
+            // 'https://randomuser.me/api/portraits/men/20.jpg',
+            // 'https://avatars.githubusercontent.com/u/739984?v=4',
+            // 'https://avatars.githubusercontent.com/u/739984?v=4',
+            // 'https://avatars.githubusercontent.com/u/739984?v=4'
+          ],
+          description: 'Jane + 4 others did a thing',
+          action: {
+            buttonProps: {
+              icon: 'mdi-arrow-right-bold',
+            }
+          }
+        })">
+        Multiple Avatars
+      </v-btn>
+      <v-btn @click="toast('Several people liked your post', {
+          cardProps: {
+            color: 'blue-grey-darken-4'
+          },
+          vertical: true,
+          multipleAvatars: [
+            'https://randomuser.me/api/portraits/women/25.jpg',
+            'https://randomuser.me/api/portraits/women/24.jpg',
+            'https://randomuser.me/api/portraits/men/20.jpg',
+          ],
+          description: 'Mary and 4 others liked your post',
+          prependIcon: 'mdi-heart',
+          prependIconProps: {
+            color: 'error'
+          },
+        })">
+        Multiple With Icon
+      </v-btn>
+    </div>
+  </div>
+</template>

--- a/src/WithProgressBars.vue
+++ b/src/WithProgressBars.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { toast } from '@/.'
+
+const promise = () => new Promise((resolve) => setTimeout(() => 
+  resolve('Some Data'), 
+  2000));
+const promiseError = () => new Promise((_, reject) => setTimeout(() => 
+  reject('This error'), 
+  2000));
+</script>
+<template>
+  <div>
+    <h2>Progress Bar</h2>
+    <p>You can remove or customize the progress bar</p>
+    <div class="buttons mt-2">
+      <v-btn @click="toast('Progress bar removed', {progressBar: false})">
+        No P Bar
+      </v-btn>
+      <v-btn @click="toast('Progress bar color and height changed', {progressBarProps: {color: 'error', height: 12}})">
+        P Bar Props
+      </v-btn>
+      <v-btn @click="toast('Progress bar reversed', {reverseProgressBar: true})">
+        Reverse P Bar
+      </v-btn>
+      <v-btn @click="toast('Progress bar indefinite (loading)', {loading: true})">
+        Indefinite P Bar
+      </v-btn>
+      <v-btn @click="toast.toastOriginal.promise(promise, {
+        loading: 'Loading...', 
+        success: (data) => {
+          toast.success(`Successful operation: ${data}`, {action: {
+          buttonProps: {
+            icon: 'mdi-close'
+          },
+          onClick: () => {}
+        }})
+          return `Operation complete: ${data} was returned`;
+        },
+        error: (data: any) => 'Error',
+        action: {
+          label: 'Close',
+          onClick: () => {}
+        }
+      }
+      )">
+        Promise (success)
+      </v-btn>
+      <v-btn @click="toast.toastOriginal.promise(promiseError, {
+        loading: 'Loading...', 
+        success: (data) => {
+          return `Operation complete: ${data} was returned`;
+        },
+        error: (data: any) => { 
+          toast.error(`Error: ${data}`, {
+            action: {
+              buttonProps: {
+                icon: 'mdi-close'
+              },
+              onClick: () => {}
+            }
+          })
+          return `Error: ${data}`
+        },
+      }
+      )">
+        Promise (error)
+      </v-btn>
+    </div>
+  </div>
+
+</template>


### PR DESCRIPTION
#### What does this PR do?
* Resolves #30 
* Allows for Avatar in toast (with multiple avatars also possible up to 5)
* Allows for countdown progress bar in toast (default behavior)
* Updates README.md with relevant info on changes

#### Description of Task to be completed?
 - [x] #30 

#### How should this be manually tested?
After cloning the repo, `cd` into it and do the following: 
```bash
# install dependencies
$ pnpm install

# start development server to view UI
$ pnpm run dev
```
After starting the server, the new changes can be viewed by opening `localhost:5173`, click new buttons to see changes in demo

#### Any background context you want to provide?
I just wanted a cool stackable toast bro, this is the closest I could find so, might as well do what I can to make it how I'd like it to be.

#### What are the relevant Notion/JIRA stories/tickets?
* #30 

#### Screenshots (if appropriate)
![image](https://github.com/wobsoriano/vuetify-sonner/assets/23138415/1b632a7f-1602-49e8-b708-af052c1ec9a0)


https://github.com/wobsoriano/vuetify-sonner/assets/23138415/9fcaeabf-597a-4281-90b4-5f61a91e2ac6
